### PR TITLE
Get brother component sample

### DIFF
--- a/app/javascript/packs/controllers/home/page1.vue
+++ b/app/javascript/packs/controllers/home/page1.vue
@@ -2,6 +2,7 @@
   <div class="page1">
     page1area
     <p>{{ message }}</p>
+    <button @click="callSampleComponent">change</button>
   </div>
 </template>
 
@@ -17,6 +18,12 @@ export default {
   data: function () {
     return {
       message: "Hello Vue Page1!"
+    }
+  },
+  methods: {
+    callSampleComponent: function() {
+      let component = this.$parent.$children.find(child => { return child.$options._componentTag === "sample" })
+      component.message = "changed sample component!"
     }
   }
 }


### PR DESCRIPTION
> vue routerの下のコンポーネント(page1)からその親のコンポーネント(sample)を呼び出せる方法

上記のサンプルコードを実装しました。


### 問題点
$parent / $childrenはあまり使わない方が良いみたいです。。。

[https://jp.vuejs.org/v2/api/#parent](url)

> $parent と $children の使用は控えてください。これらはどうしても避けられないときに使用します。親子間の通信に対してプロパティとイベントを使用すべきです。

[https://jp.vuejs.org/v2/guide/components-edge-cases.html#%E8%A6%AA%E3%82%B3%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%8D%E3%83%B3%E3%83%88%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%BF%E3%83%B3%E3%82%B9%E3%81%B8%E3%81%AE%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9](url)
> ほとんどのケースで、親へのアクセスはアプリケーションのデバッグや理解をより難しくします。