### PR TITLE
Simplify and fix pagination bug

### DIFF
--- a/app/assets/javascripts/api/v1/total_page.coffee
+++ b/app/assets/javascripts/api/v1/total_page.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/api/v1/total_page.scss
+++ b/app/assets/stylesheets/api/v1/total_page.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the api/v1/total_page controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api/v1/searches_controller.rb
+++ b/app/controllers/api/v1/searches_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::SearchesController < ApplicationController
   def index
     @results = Uspto::SearchService.new(params[:my_params]).run
-    render json: @results["docs"]
+    render json: {docs: @results["docs"], total_count: @results["numFound"]}
   end
 end

--- a/app/controllers/api/v1/total_page_controller.rb
+++ b/app/controllers/api/v1/total_page_controller.rb
@@ -1,6 +1,0 @@
-class Api::V1::TotalPageController < ApplicationController
-  def index
-    @results = Uspto::SearchService.new(params[:my_params]).run
-    render json: @results["numFound"]
-  end
-end

--- a/app/helpers/api/v1/total_page_helper.rb
+++ b/app/helpers/api/v1/total_page_helper.rb
@@ -1,2 +1,0 @@
-module Api::V1::TotalPageHelper
-end

--- a/app/javascript/packs/controllers/home/index.vue
+++ b/app/javascript/packs/controllers/home/index.vue
@@ -36,9 +36,10 @@
       <div class="col-sm-4 col-sm-offset-4">
         <el-pagination
           layout="prev, pager, next"
-          page-size= 25
-          :total="number"
-          @current-change="setPage">
+          :page-size="25"
+          :total="total"
+          @current-change="setPage"
+          :current-page.sync="page">
         </el-pagination>
       </div>
     </div>
@@ -57,15 +58,18 @@
       return{
         errors: [],
         results: [],
-        number: [],
+        total: 0,
         word:  "",
-        page: 0,
+        page: 1,
       }
     },
 
     methods: {
       setPage (val) {
         this.page = val
+        this.searchPatents();
+      },
+      searchPatents (val) {
         axios
           .get('/api/v1/searches',{
             params: {
@@ -73,13 +77,13 @@
             },
           })
           .then((response) => {
-            let i = 0;
-            i < response.data.length;
-            i++;
-            this.results.push(response.data[i]);
+            this.results = [];
+            for(let i = 0; i < response.data.docs.length; i++) {
+              this.results.push(response.data.docs[i]);
+            }
+            this.total = response.data.total_count
           })
       },
-
       exec: function(){
         this.errors.length = 0;
         if(!this.word){
@@ -96,40 +100,7 @@
           },3000);
           return;
         }
-
-        axios
-        .get('/api/v1/total_page',{
-          params: {
-            my_params: [this.word, this.page]
-          },
-        })
-        .then(response => (this.number = response.data))
-
-        axios
-        .get('/api/v1/searches',{
-          params: {
-            my_params: [this.word, this.page],
-          },
-        })
-        .then((response) => {
-          this.results.length = 0;
-          if(!response.data.length){
-            for(let i = 0; i < alert.length; i++){
-              alert[i].style.display="block";
-            }
-            this.errors.push("指定された条件の特許が存在しません");
-            setTimeout(function(){
-              for(let i = 0; i < alert.length; i++){
-                alert[i].style.display="none";
-                }
-            },3000);
-          }
-          for(let i = 0; i < response.data.length; i++) {
-            this.results.push(response.data[i]);
-          }
-         }, (error) => {
-           console.log(error);
-         });
+        this.searchPatents();
       }
     }
   };

--- a/app/services/uspto/search_service.rb
+++ b/app/services/uspto/search_service.rb
@@ -3,6 +3,7 @@ module Uspto
     def initialize(my_params)
       @word = my_params[0]
       @page = my_params[1]
+      @offset = (@page.to_i - 1) * 25
 
     end
 
@@ -19,7 +20,7 @@ module Uspto
         "qf":"appEarlyPubNumber applId appLocation appType appStatus_txt appConfrNumber appCustNumber appGrpArtNumber appCls appSubCls appEntityStatus_txt patentNumber patentTitle primaryInventor firstNamedApplicant appExamName appExamPrefrdName appAttrDockNumber appPCTNumber appIntlPubNumber wipoEarlyPubNumber pctAppType firstInventorFile appClsSubCls rankAndInventorsList",
         "facet":"false",
         "sort":"applId asc",
-        "start":"#{@page}"
+        "start":"#{@offset}"
       }
       headers = { "Content-Type" => "application/json" }
       d_response = http.post(uri.path, a_params.to_json, headers)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,12 +11,6 @@ Rails.application.routes.draw do
       end
     end
 
-    namespace :api, {format: 'json'} do
-      namespace :v1 do
-        resources :total_page, only: [:index]
-      end
-    end
-
     get "dashboard", to: 'dashboard#index'
     devise_for :users, controllers: {
       passwords: "users/passwords",

--- a/test/controllers/api/v1/searches_controller_test.rb
+++ b/test/controllers/api/v1/searches_controller_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class Api::V1::SearchesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
* トータルカウントの取得を別APIにするのではなく、同じ検索の結果を利用するようにしました。
* APIのstartパラメータはoffsetの意だったようなので1ページ移動しても1件しか移動しておらず、25件中24件は同じ結果が得られていたので、正しくoffsetでページングができるように修正しました。
* jsをシンプルにしました。
* 不要なファイルを削除しました。